### PR TITLE
Change build to use npm ci instead of npm i

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,6 +19,6 @@ jobs:
 
       - name: Install dependencies, check formatting and build
         run: |
-          npm install
+          npm ci 
           npm run check:format
           npm run build


### PR DESCRIPTION
## Changes in this PR

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Breaking change of an existing feature
-   [x] Refactor/Performance enhancements

## Overview

- Use `npm ci` instead of `npm install` in build script
